### PR TITLE
Bug/parameter and units comparisons

### DIFF
--- a/src/main/java/calibration/model/Analysis.java
+++ b/src/main/java/calibration/model/Analysis.java
@@ -270,7 +270,7 @@ public class Analysis {
         }
 
         if (observedTsc.isPresent() && computedTsc.isPresent()) {
-            if (this.computedTsc.units.equals(this.observedTsc.units)) {
+            if (this.computedTsc.units.equalsIgnoreCase(this.observedTsc.units)) {
                 units = this.computedTsc.units;
             } else {
                 errors++;
@@ -279,23 +279,8 @@ public class Analysis {
                 valid = false;
             }
         }
-
-        if (observedTsc.isPresent() && computedTsc.isPresent()) {
-            String observedParameter = this.observedTsc.parameter.split("-")[0];
-            String computedParameter = this.computedTsc.parameter.split("-")[0];
-
-            if (computedParameter.equals(observedParameter)) {
-                parameter = observedParameter;
-            } else {
-                errors++;
-                String errorMessage = "Computed and observed parameters are not equivalent\n";
-                errorMessages.append(errorMessage);
-                valid = false;
-            }
-        }
-
+        parameter = this.computedTsc.parameter;
         this.errorMessages = errorMessages.toString();
-
     }
 
     private void computeStatistics() throws HecMathException {


### PR DESCRIPTION
Unit comparison just ignores case now. Parameters is a little better, but still not perfect. it used to just check that the first parts of parameter matched, so Flow wouldn't match PER-AVER Flow. Now it checks that the first word of the computer parameter is contained in the observed parameter, so that case would pass. 

It's really hard to imagine the validation to make this work for all cases. I'd advocate we remove this check all together. Give the user a rope to hang themself with. I'm not sure the benefits we're getting out of this check are worth the pain. I'll leave that to someone else to decide though. 