### PR TITLE
Add a headless compute option

### DIFF
--- a/src/main/java/calibration/CalibrationApp.java
+++ b/src/main/java/calibration/CalibrationApp.java
@@ -194,8 +194,9 @@ public class CalibrationApp extends Application {
      * Loads person data from the specified file. The current data will be replaced.
      *
      * @param file
+     * @param headlessCompute true if computing headless, false if computing from the UI
      */
-    public void loadAnalysisFromFile(File file) {
+    public void loadAnalysisFromFile(File file, boolean headlessCompute) {
         try {
             JAXBContext context = JAXBContext.newInstance(Analysis.class);
             Unmarshaller um = context.createUnmarshaller();
@@ -203,9 +204,11 @@ public class CalibrationApp extends Application {
             // Reading XML from the file and unmarshalling.
             this.analysis = (Analysis) um.unmarshal(file);
 
-            // Save the file path to the registry.
-            setAnalysisFile(Optional.ofNullable(file));
-            setPersistedFile(Optional.ofNullable(file));
+            if (!headlessCompute) {
+                // Save the file path to the registry.
+                setAnalysisFile(Optional.ofNullable(file));
+                setPersistedFile(Optional.ofNullable(file));
+            }
 
         } catch (Exception e) { // catches ANY exception
             Alert alert = new Alert(AlertType.ERROR);

--- a/src/main/java/calibration/view/RootLayoutController.java
+++ b/src/main/java/calibration/view/RootLayoutController.java
@@ -285,7 +285,7 @@ public class RootLayoutController implements Initializable {
 		}
 
         if (file != null) {
-            app.loadAnalysisFromFile(file);
+            app.loadAnalysisFromFile(file, false);
             computedDssTextField.setText(app.getAnalysis().getComputedDssFile());
         	computedDssPathTextField.setText(app.getAnalysis().getComputedDssPath());
         	observedDssTextField.setText(app.getAnalysis().getObservedDssFile());


### PR DESCRIPTION
Allow for headless computes. Avoid an NPE by not writing registry.

Resolves: HMS-3935